### PR TITLE
Fix python being only allowed to install python 3.10

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=${{ python_min }},<3.13
+    - python ${{ python_min }}.*
     - hatchling
     - pip
   run:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,17 +12,17 @@ source:
   sha256: 1dcbdfc6760761b5a5960848e1a3aa69f20143fcb522746db7ebdd315fb9fb3b
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python ${{ python_min }}.*,<3.13
+    - python >=${{ python_min }},<3.13
     - hatchling
     - pip
   run:
-    - python ${{ python_min }}.*,<3.13
+    - python >=${{ python_min }},<3.13
     - aiohttp
     - onnxruntime
     - chardet

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: "2.0.2"
+  python_min: "3.10"
 
 package:
   name: coastseg


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The last version of the recipe had the python version set to `python ${{ python_min }}.*,<3.13` which resulted in coastseg not being able to be installed in python 3.11 and 3.12. I have fixed this issue in this version by setting `python >=${{ python_min }},<3.13` and tested all 3 versions locally on my windows machine. 